### PR TITLE
add option for writable off-diagonal elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,47 @@ julia> mul!(copy(y), AP, x, α, β)  # or use the equivalent julian interface
  0.9592679333345454
  0.27783932357851576
 ```
+
+`SymmetricPacked` differs in one important aspect to `LinearAlgebra.Symmetric`
+in that it optionally permits off diagonal elements to be set.  Continuing
+from the example above:
+
+```
+julia> AP[1,1]=5
+5
+
+julia> AP
+5×5 SymmetricPacked{Float64, Matrix{Float64}, Val{:RO}()}:
+ 5.0       0.736451   0.704095   0.842738  0.207618
+ 0.736451  0.63549    0.861638   0.834968  0.0660772
+ 0.704095  0.861638   0.131074   0.727387  0.0995039
+ 0.842738  0.834968   0.727387   0.96513   0.616451
+ 0.207618  0.0660772  0.0995039  0.616451  0.369353
+
+julia> AP[1,5]=5
+ERROR: ArgumentError: Cannot set a non-diagonal index in a symmetric matrix
+Stacktrace:
+ [1] setindex!(A::SymmetricPacked{Float64, Matrix{Float64}, Val{:RO}()}, v::Int64, i::Int64, j::Int64)
+   @ PackedArrays ~/projects/darshan/PackedArrays/src/PackedArrays.jl:114
+ [2] top-level scope
+   @ REPL[7]:1
+
+julia> APRW = SymmetricPacked(A, :L, Val(:RW))  # default is :RO
+5×5 SymmetricPacked{Float64, Matrix{Float64}, Val{:RW}()}:
+ 0.364856   0.0797498   0.152769    0.201612   0.283603
+ 0.0797498  0.63549     0.00271082  0.0429332  0.818754
+ 0.152769   0.00271082  0.131074    0.682401   0.76548
+ 0.201612   0.0429332   0.682401    0.96513    0.284176
+ 0.283603   0.818754    0.76548     0.284176   0.369353
+
+julia> APRW[1,5]=5
+5
+
+julia> APRW
+5×5 SymmetricPacked{Float64, Matrix{Float64}, Val{:RW}()}:
+ 0.364856   0.0797498   0.152769    0.201612   5.0
+ 0.0797498  0.63549     0.00271082  0.0429332  0.818754
+ 0.152769   0.00271082  0.131074    0.682401   0.76548
+ 0.201612   0.0429332   0.682401    0.96513    0.284176
+ 5.0        0.818754    0.76548     0.284176   0.369353
+```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,40 @@ A = collect(reshape(1:9.0,3,3))
     @test_throws ArgumentError APL[1,3]=3
 end
 
+@testset "read/write upper" begin
+    APU = SymmetricPacked(A, :U, Val(:RW))
+
+    @test APU[1,1] == A[1,1]
+    @test APU[1,2] == A[1,2]
+    @test APU[1,3] == A[1,3]
+    @test APU[2,1] == A[1,2]
+    @test APU[2,2] == A[2,2]
+    @test APU[2,3] == A[2,3]
+    @test APU[3,1] == A[1,3]
+    @test APU[3,2] == A[2,3]
+    @test APU[3,3] == A[3,3]
+
+    APU[1,2] = 0
+    @test APU[2,1] == 0
+end
+
+@testset "read/write lower" begin
+    APL = SymmetricPacked(A, :L, Val(:RW))
+
+    @test APL[1,1] == A[1,1]
+    @test APL[1,2] == A[2,1]
+    @test APL[1,3] == A[3,1]
+    @test APL[2,1] == A[2,1]
+    @test APL[2,2] == A[2,2]
+    @test APL[2,3] == A[3,2]
+    @test APL[3,1] == A[3,1]
+    @test APL[3,2] == A[3,2]
+    @test APL[3,3] == A[3,3]
+
+    APL[1,2] = 0
+    @test APL[2,1] == 0
+end
+
 @testset "mul!" begin
     for uplo in [:U, :L]
         y = Float64[1,2,3]


### PR DESCRIPTION
@mkitti this is the first time i've used value types.  can you please review?

the idea is that `LinearAlgebra.Symmetric` does *not* allow the off diagonal elements to be set, and so neither should the default `PackedArrays.SymmetricPacked`.  but some might want this so add it as an option.